### PR TITLE
Theking2 usermapping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # Source image
 FROM wordpress:7.0-php8.4-apache
 ARG UPLOADS_INI="/usr/local/etc/php/conf.d/uploads.ini"
+ARG USER_ID=1000
+ARG GROUP_ID=1000
 
 # Install AND configure Xdebug
 RUN pecl install xdebug \

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,7 @@
 name: ${project}
 volumes:
   db:
+  wp:
 networks:
   default:
     name: ${project}
@@ -18,7 +19,11 @@ services:
       - db:/var/lib/mysql
 
   wp:
-    build: ./
+    build:
+      context: ./
+      args:
+        USER_ID: ${UID:-1000}
+        GROUP_ID: ${GID:-1000}
     container_name: ${project}-wp
     depends_on:
       - db
@@ -28,6 +33,7 @@ services:
       WORDPRESS_DB_PASSWORD: wordpress
       WORDPRESS_DB_NAME: wordpress
     volumes:
+      -  wp:/var/www/html
       - ./app:/var/www/html/wp-content
       - ./xdebug.ini:/usr/local/etc/php/conf.d/xdebug.ini 
       - ./logs:/var/log


### PR DESCRIPTION
This pull request introduces improvements to the Docker and Compose setup for the WordPress project, focusing on better volume management and support for custom user/group IDs during container builds. The most important changes are grouped below.

**Docker build customization:**

* Added `USER_ID` and `GROUP_ID` build arguments to the `Dockerfile` to allow setting custom user and group IDs at build time.
* Updated the `wp` service build configuration in `compose.yaml` to pass `USER_ID` and `GROUP_ID` from environment variables (defaulting to 1000 if not set).

**Volume management:**

* Defined a new named volume `wp` in `compose.yaml` for persistent WordPress data.
* Mounted the new `wp` volume to `/var/www/html` in the `wp` service, ensuring WordPress core files are persisted across container restarts.